### PR TITLE
Mollyjones2723/sc 154157/update python sdk hello app readme and comments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,8 @@ jobs:
       - run:
           name: Insert key and flag data into demo
           command: |
-            sed -i "s/YOUR_SDK_KEY/${LD_HELLO_WORLD_SDK_KEY}/" hello.r
-            sed -i "s/YOUR_FEATURE_KEY/${LD_HELLO_WORLD_FLAG_KEY_WITH_TRUE_VALUE}/" hello.r
+            sed -i "s/SDK_KEY=*\".*\"/SDK_KEY=\"${LD_HELLO_WORLD_SDK_KEY}\"/" hello.r
+            sed -i "s/FEATURE_FLAG_KEY=*\".*\"/FEATURE_FLAG_KEY=\"${LD_HELLO_WORLD_FLAG_KEY_WITH_TRUE_VALUE}\"/" hello.r
       - run:
           name: Run Demo
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,4 +43,4 @@ jobs:
           name: Run Demo
           command: |
               Rscript hello.r | tee output.txt
-              grep -q "feature is launched" output.txt || (echo "Flag did not evaluate to expected true value" && exit 1)
+              grep -q "is true for this user" output.txt || (echo "Flag did not evaluate to expected true value" && exit 1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           name: Insert key and flag data into demo
           command: |
             sed -i "/^SDK_KEY=/c SDK_KEY=\"${LD_HELLO_WORLD_SDK_KEY}\"/" hello.r
-            sed -i "s/my-boolean-flag/${LD_HELLO_WORLD_FLAG_KEY_WITH_TRUE_VALUE}/" hello.r
+            sed -i "/^FEATURE_FLAG_KEY=/c FEATURE_FLAG_KEY=\"${LD_HELLO_WORLD_FLAG_KEY_WITH_TRUE_VALUE}\"/" hello.r
       - run:
           name: Run Demo
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           name: Insert key and flag data into demo
           command: |
             sed -i "/^SDK_KEY=/c SDK_KEY=\"${LD_HELLO_WORLD_SDK_KEY}\"/" hello.r
-            sed -i "/^FEATURE_FLAG_KEY=/c FEATURE_FLAG_KEY=\"${LD_HELLO_WORLD_FLAG_KEY_WITH_TRUE_VALUE}\"/" hello.r
+            sed -i "s/FEATURE_FLAG_KEY=*\".*\"/FEATURE_FLAG_KEY=\"${LD_HELLO_WORLD_FLAG_KEY_WITH_TRUE_VALUE}\"/" hello.r
       - run:
           name: Run Demo
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,8 @@ jobs:
       - run:
           name: Insert key and flag data into demo
           command: |
-            sed -i "s/SDK_KEY=*\".*\"/SDK_KEY=\"${LD_HELLO_WORLD_SDK_KEY}\"/" hello.r
-            sed -i "s/FEATURE_FLAG_KEY=*\".*\"/FEATURE_FLAG_KEY=\"${LD_HELLO_WORLD_FLAG_KEY_WITH_TRUE_VALUE}\"/" hello.r
+            sed -i "/^SDK_KEY=/c SDK_KEY=\"${LD_HELLO_WORLD_SDK_KEY}\"/" hello.r
+            sed -i "s/my-boolean-flag/${LD_HELLO_WORLD_FLAG_KEY_WITH_TRUE_VALUE}/" hello.r
       - run:
           name: Run Demo
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Insert key and flag data into demo
           command: |
-            sed -i "/^SDK_KEY=/c SDK_KEY=\"${LD_HELLO_WORLD_SDK_KEY}\"/" hello.r
+            sed -i "s/SDK_KEY=*\".*\"/SDK_KEY=\"${LD_HELLO_WORLD_SDK_KEY}\"/" hello.r
             sed -i "s/FEATURE_FLAG_KEY=*\".*\"/FEATURE_FLAG_KEY=\"${LD_HELLO_WORLD_FLAG_KEY_WITH_TRUE_VALUE}\"/" hello.r
       - run:
           name: Run Demo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# LaunchDarkly Sample R Server-Side Application
-We've built a simple console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the basic build procedure. While LaunchDarkly does not have a dedicated R SDK, you can use the Python SDK. Use this as a starting point for integrating the `python-server-sdk` with your R application. To learn more, read the [Python SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/python).
+# LaunchDarkly sample R Server-Side Application
+We've built a console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the basic build procedure. While LaunchDarkly does not have a dedicated R SDK, you can use the Python SDK. Use this as a starting point for integrating the `python-server-sdk` with your R application. To learn more, read the [Python SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/python).
 
 ## Dependencies
 1. Install the reticulate package: `R -e "install.packages('reticulate')"`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LaunchDarkly sample R Server-Side Application
+# LaunchDarkly sample R server-side application
 We've built a console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the basic build procedure. While LaunchDarkly does not have a dedicated R SDK, you can use the Python SDK. Use this as a starting point for integrating the `python-server-sdk` with your R application. To learn more, read the [Python SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/python).
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # LaunchDarkly Sample R Server-Side Application
-We've built a simple console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the basic build procedure. While LaunchDarkly does not have a dedicated R SDK, the Python SDK can be conveniently utilized. Use this as a starting point for integrating the `python-server-sdk` with your R application. To learn more, read the [Python SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/python).
+We've built a simple console application that demonstrates how LaunchDarkly's SDK works. Below, you'll find the basic build procedure. While LaunchDarkly does not have a dedicated R SDK, you can use the Python SDK. Use this as a starting point for integrating the `python-server-sdk` with your R application. To learn more, read the [Python SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/python).
 
 ## Dependencies
-- Install the reticulate package `R -e "install.packages('reticulate')"`
-- Install the LaunchDarkly Python SDK `pip3 install launchdarkly-server-sdk`
+1. Install the reticulate package: `R -e "install.packages('reticulate')"`
+2. Install the LaunchDarkly Python SDK: `pip3 install launchdarkly-server-sdk`
 
-## Instructions
-1. Install the dependencies described above
-2. Copy your SDK key and feature flag key from your LaunchDarkly dashboard into `hello.r`
-5. Run `Rscript hello.r`
+## Build instructions
+1. Edit `hello.r` and set the value of `SDK_KEY` to your LaunchDarkly SDK key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `FEATURE_FLAG_KEY` to the flag key.
+
+```
+SDK_KEY="sdk-1234567890abcdef"
+FEATURE_FLAG_KEY="my-boolean-flag"
+```
+
+2. On the command line, run `Rscript hello.r`.
+
+You should receive the message "Feature flag '<flag key>' is <true/false> for this user".

--- a/hello.r
+++ b/hello.r
@@ -1,18 +1,27 @@
 library(reticulate)
 
 # Set SDK_KEY to your LaunchDarkly SDK key
-SDK_KEY="YOUR_SDK_KEY"
+SDK_KEY=""
 # Set FEATURE_FLAG_KEY to the feature flag key you want to evaluate
-FEATURE_FLAG_KEY="YOUR_FEATURE_KEY"
+FEATURE_FLAG_KEY="my-boolean-flag"
 
 ldclient <- import("ldclient")
 
 ldclient$set_config(ldclient$config$Config(SDK_KEY))
 
-user = list(key = "alice@example.com")
+# Set up the user properties. This user should appear on your LaunchDarkly
+# users dashboard soon after you run the demo.
+user = list(key = "example-user-key", name="Sandy")
 
 if (ldclient$get()$variation(FEATURE_FLAG_KEY, user, FALSE)) {
-    print("feature is launched")
+    print("Feature flag %s is true for this user", FEATURE_FLAG_KEY)
 } else {
-    print("feature is hidden")
+    print("Feature flag %s is false for this user", FEATURE_FLAG_KEY)
 }
+
+# Here we ensure that the SDK shuts down cleanly and has a chance to deliver analytics
+# events to LaunchDarkly before the program exits. If analytics events are not delivered,
+# the user properties and flag usage statistics will not appear on your dashboard. In a
+# normal long-running application, the SDK would continue running and events would be
+# delivered automatically in the background.
+ldclient$get()$close()

--- a/hello.r
+++ b/hello.r
@@ -9,6 +9,13 @@ ldclient <- import("ldclient")
 
 ldclient$set_config(ldclient$config$Config(SDK_KEY))
 
+if (ldclient$get()$is_initialized()) {
+  cat("SDK successfully initialized!")
+} else {
+  cat("SDK failed to initialize")
+  exit()
+}
+
 # Set up the user properties. This user should appear on your LaunchDarkly
 # users dashboard soon after you run the demo.
 user = list(key = "example-user-key", name="Sandy")

--- a/hello.r
+++ b/hello.r
@@ -14,9 +14,9 @@ ldclient$set_config(ldclient$config$Config(SDK_KEY))
 user = list(key = "example-user-key", name="Sandy")
 
 if (ldclient$get()$variation(FEATURE_FLAG_KEY, user, FALSE)) {
-    print("Feature flag %s is true for this user", FEATURE_FLAG_KEY)
+    cat("Feature flag", FEATURE_FLAG_KEY, "is true for this user")
 } else {
-    print("Feature flag %s is false for this user", FEATURE_FLAG_KEY)
+    cat("Feature flag", FEATURE_FLAG_KEY, "is false for this user")
 }
 
 # Here we ensure that the SDK shuts down cleanly and has a chance to deliver analytics


### PR DESCRIPTION
[SC-154157](https://app.shortcut.com/launchdarkly/story/154157/update-python-sdk-hello-app-readme-and-comments-to-standard-design): After receiving some feedback that it'd be helpful if the Hello apps were more standardized,  Docs team is working on updating them to [match the spec](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/1499562073/SDK+hello+world).

Updates:
* use [standard readme content](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/1499562073/SDK+hello+world#Example-README.md)
* update `hello.r` to add initialization check, call close at the end, and use the code comments and initial variable values from the spec
* update the CircleCI tests based on the updated messages and initial variable values