### PR TITLE
fix: install libpng-dev and pin reticulate to correct Python for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
 
       - uses: r-lib/actions/setup-r@929c772977a3a13c8733b363bf5a2f685c25dd91
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpng-dev
+
       - name: Install dependencies
         run: |
           R -e 'install.packages("reticulate")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,13 @@ jobs:
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
 
+    env:
+      RETICULATE_PYTHON: ${{ github.workspace }}/.venv/bin/python
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
@@ -37,7 +40,8 @@ jobs:
       - name: Install dependencies
         run: |
           R -e 'install.packages("reticulate")'
-          pip install launchdarkly-server-sdk
+          python -m venv .venv
+          .venv/bin/pip install launchdarkly-server-sdk
 
       - uses: launchdarkly/gh-actions/actions/verify-hello-app@verify-hello-app-v2.0.0
         with:


### PR DESCRIPTION
## Summary

The CI build was failing due to two issues:

**1. Missing `libpng-dev` system package**
The `reticulate` R package's dependency `png` fails to compile on `ubuntu-latest` because `libpng-dev` is not installed. Added an explicit step to install it.

```
/bin/bash: line 1: libpng-config: command not found
read.c:3:10: fatal error: png.h: No such file or directory
ERROR: compilation failed for package 'png'
ERROR: dependency 'png' is not available for package 'reticulate'
```

**2. `reticulate` using wrong Python**
After fixing the first issue, `reticulate` was downloading its own Python 3.12 via `uv` instead of using the Python 3.8 where `launchdarkly-server-sdk` was pip-installed, causing `ModuleNotFoundError: No module named 'ldclient'`. Fixed by creating a venv from the setup-python installation and setting `RETICULATE_PYTHON` to point to it.

**Root cause run:** [failed run](https://github.com/launchdarkly/hello-r/actions/runs/22994680706)

## Review & Testing Checklist for Human

- [ ] Verify CI passes on this PR (it did on the latest push, but confirm it stays green)
- [ ] Confirm the `RETICULATE_PYTHON` + venv approach is the preferred way to pin reticulate to a specific Python — an alternative would be calling `reticulate::use_python()` in `main.r` or setting `RETICULATE_PYTHON_ENV`
- [ ] Consider whether Python 3.8 (EOL) should be bumped to a supported version in a follow-up — this is a pre-existing concern, not introduced by this PR

### Notes
- Requested by: @kinyoklion
- [Devin Session](https://app.devin.ai/sessions/478dd8f571d94640ac51bd339acfd05d)